### PR TITLE
fix: allow a space before/after a keyword

### DIFF
--- a/packages/eslint-config-typescript/lib/index.js
+++ b/packages/eslint-config-typescript/lib/index.js
@@ -100,7 +100,10 @@ module.exports = {
         tuples: 'always-multiline',
       }],
 
-      '@typescript-eslint/keyword-spacing': ['error', { before: true }],
+      '@typescript-eslint/keyword-spacing': ['error', {
+        before: true,
+        after: true,
+      }],
 
       // indent not used yet because https://github.com/typescript-eslint/typescript-eslint/issues/1824
       // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/indent.md

--- a/packages/eslint-config-typescript/lib/index.js
+++ b/packages/eslint-config-typescript/lib/index.js
@@ -100,7 +100,7 @@ module.exports = {
         tuples: 'always-multiline',
       }],
 
-      '@typescript-eslint/keyword-spacing': 'error',
+      '@typescript-eslint/keyword-spacing': ['error', { before: true }],
 
       // indent not used yet because https://github.com/typescript-eslint/typescript-eslint/issues/1824
       // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/indent.md


### PR DESCRIPTION
This allows `import type { Sequelize } from './sequelize'` instead of `import type{ Sequelize } from './sequelize'`
(and `import type origValidator` instead of `import typeorigValidator`)